### PR TITLE
Fixed bug where last array element is empty

### DIFF
--- a/system/model.php
+++ b/system/model.php
@@ -22,7 +22,7 @@ class Model {
 		$result = mysql_query($qry) or die('MySQL Error: '. mysql_error());
 		$resultObjects = array();
 
-		while($resultObjects[] = mysql_fetch_object($result));
+		while($row = mysql_fetch_object($result)) $resultObjects[] = $row;
 
 		return $resultObjects;
 	}


### PR DESCRIPTION
I noticed that this function was returning arrays with empty final elements.
This edit fixes that bug.
