### PR TITLE
Change to Segment Helper Function

### DIFF
--- a/application/helpers/url_helper.php
+++ b/application/helpers/url_helper.php
@@ -10,12 +10,10 @@ class Url_helper {
 	
 	function segment($seg)
 	{
-		$url = trim($_GET['_url'], '/');
-		$parts = explode('/', $url);
-        if(isset($parts[$seg]))
-            return $parts[$seg];
-        else
-            return false;
+		if(!is_int($seg)) return false;
+		
+		$parts = explode('/', $_SERVER['REQUEST_URI']);
+	    return isset($parts[$seg]) ? $parts[$seg] : false;
 	}
 	
 }


### PR DESCRIPTION
I changed the segment function to use REQUEST_URI from the $_SERVER array. The $_GET['_url'] variable wasn't working for me. I couldn't find any documentation of this variable being in the $_GET array by default. This new function also does an integer check to the variable passed in and returns false if not an integer.
