### PR TITLE
Routing routine can cope with question marks

### DIFF
--- a/system/pip.php
+++ b/system/pip.php
@@ -16,6 +16,9 @@ function pip()
 	// Get our url path and trim the / of the left and the right
 	if($request_url != $script_url) $url = trim(preg_replace('/'. str_replace('/', '\/', str_replace('index.php', '', $script_url)) .'/', '', $request_url, 1), '/');
     
+	// Remove string after possible question mark
+	if (stripos($url, '?') > 0) $url = substr($url, 0, stripos($url, '?'));
+	
 	// Split the url into segments
 	$segments = explode('/', $url);
 	


### PR DESCRIPTION
The routing routine failed when e.g. a third party added normal "question mark GET parameters" to the URL. With this commit these parameters are removed before the URL parts are separated.

I had this problem when I integrated for example the Facebook login. After the login of the user Facebook will redirect him or her to [myURL]?code=[someHash] and this used to break PIPs routing system.
